### PR TITLE
本番環境／開発環境で使用するサーバURLの変数が切り替わる

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+REACT_APP_API_URL=http://localhost:3004/todoList

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+REACT_APP_API_URL=http://localhost:3004/todoList

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "web-vitals": "^1.1.2"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
+    "start": "REACT_APP_URL=http://localhost:3004/todoList react-scripts start",
+    "build": "REACT_APP_URL=http://localhost:3004/todoList react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "serve": "npx json-server --watch db.json --port 3004",

--- a/src/App.js
+++ b/src/App.js
@@ -3,9 +3,7 @@ import { useState, useEffect } from "react";
 import "./App.scss";
 import axios from "axios";
 
-import { Config } from "./Config";
-
-const DATA_URL = Config();
+const DATA_URL = process.env.REACT_APP_URL;
 
 export const App = () => {
   const [task, setTask] = useState("");

--- a/src/App.js
+++ b/src/App.js
@@ -3,7 +3,9 @@ import { useState, useEffect } from "react";
 import "./App.scss";
 import axios from "axios";
 
-const DATA_URL = "http://localhost:3004/todoList";
+import { Config } from "./Config";
+
+const DATA_URL = Config();
 
 export const App = () => {
   const [task, setTask] = useState("");

--- a/src/App.js
+++ b/src/App.js
@@ -3,7 +3,7 @@ import { useState, useEffect } from "react";
 import "./App.scss";
 import axios from "axios";
 
-const DATA_URL = process.env.REACT_APP_URL;
+const DATA_URL = process.env.REACT_APP_API_URL;
 
 export const App = () => {
   const [task, setTask] = useState("");

--- a/src/Config.js
+++ b/src/Config.js
@@ -1,7 +1,0 @@
-export const Config = () => {
-  if (process.env.NODE_ENV === "development") {
-    return "http://localhost:3004/todoList";
-  } else if (process.env.NODE_ENV === "production") {
-    return "http://localhost:3004/todoList";
-  }
-};

--- a/src/Config.js
+++ b/src/Config.js
@@ -1,0 +1,7 @@
+export const Config = () => {
+  if (process.env.NODE_ENV === "development") {
+    return "http://localhost:3004/todoList";
+  } else if (process.env.NODE_ENV === "production") {
+    return "http://localhost:3004/todoList";
+  }
+};


### PR DESCRIPTION
## 立ち上げ方法

<!-- npm run dev以外のコマンドを入力する必要がある場合は書く。 -->

開発環境: ` npm run dev`
本番環境:   ```serve -s build```

## 概要
***
本番環境／開発環境で使用するサーバURLの変数が切り替わるように設定する

## レビュー不要箇所

## レビューして欲しい部分
Config.jsで```process.env.NODE_ENV```が開発環境又は本番環境で切り替わるようにしました。
（今回サーバURLは同じにしてあります。）

全体的に書き方が適切かどうかを確認していただきたいです。


## 難しかったところ
.envファイルを使わなくても```process.env.NODE_ENV === "development"```で場合分けできていることに気づくまでに時間がかかりました。

## 資料、補足等